### PR TITLE
Feat/tribute event

### DIFF
--- a/contracts/tools/TributeEscrow.sol
+++ b/contracts/tools/TributeEscrow.sol
@@ -2,13 +2,14 @@
 pragma solidity >=0.8.0;
 import "../Baal.sol";
 
-import "hardhat/console.sol";
+//  import "hardhat/console.sol";
 
 interface IERC20 {
     function transferFrom(address from, address to, uint256 value) external returns (bool);
 }
 
 contract TributeEscrow {
+    event TributeProposal(address indexed baal, address token, uint256 amount, address recipient, uint256 proposalId);
     struct Escrow {
         address token;
         address applicant;
@@ -118,22 +119,23 @@ contract TributeEscrow {
             baal.target()
         );
         baal.submitProposal(encodedProposal, expiration, details);
+        emit TributeProposal(address(baal), token, amount, recipient, proposalId);
     }
 
     function releaseEscrow(uint32 proposalId) external {
-        console.log("releasing");
+        // console.log("releasing");
         Baal baal = Baal(msg.sender);
         Escrow storage escrow = escrows[address(baal)][proposalId];
         require(!escrow.released, "Already released");
-        console.log("releasing1b");
+        // console.log("releasing1b");
 
         bool[4] memory status = baal.getProposalStatus(proposalId);
-        console.log("releasing1c");
+        // console.log("releasing1c");
         require(status[2], "Not passed");
         escrow.released = true;
 
         IERC20 token = IERC20(escrow.token);
-        console.log("releasing2");
+        // console.log("releasing2");
 
         require(
             token.transferFrom(escrow.applicant, escrow.safe, escrow.amount),

--- a/contracts/tools/TributeEscrow.sol
+++ b/contracts/tools/TributeEscrow.sol
@@ -98,7 +98,6 @@ contract TributeEscrow {
         uint256 amount,
         uint256 shares,
         uint256 loot,
-        address recipient,
         uint32 expiration,
         string memory details
     ) public {
@@ -107,19 +106,19 @@ contract TributeEscrow {
             address(baal),
             shares,
             loot,
-            recipient,
+            msg.sender,
             proposalId,
             address(this)
         );
         escrows[address(baal)][proposalId] = Escrow(
             token,
-            recipient,
+            msg.sender,
             amount,
             false,
             baal.target()
         );
         baal.submitProposal(encodedProposal, expiration, details);
-        emit TributeProposal(address(baal), token, amount, recipient, proposalId);
+        emit TributeProposal(address(baal), token, amount, msg.sender, proposalId);
     }
 
     function releaseEscrow(uint32 proposalId) external {

--- a/test/Tribute.test.ts
+++ b/test/Tribute.test.ts
@@ -338,7 +338,7 @@ describe('Tribute proposal type', function () {
     it('allows external tribute escrow to submit share proposal in exchange for tokens', async function () {
       await applicantWeth.approve(tributeEscrow.address, 100)
 
-      await tributeEscrow.submitTributeProposal(baal.address, applicantWeth.address, 100, 100, 0, applicant.address, proposal.expiration, 'tribute')
+      await tributeEscrow.submitTributeProposal(baal.address, applicantWeth.address, 100, 100, 0, proposal.expiration, 'tribute')
       await baal.sponsorProposal(1)
       await baal.submitVote(1, yes)
       await moveForwardPeriods(2)

--- a/test/Tribute.test.ts
+++ b/test/Tribute.test.ts
@@ -21,10 +21,6 @@ import { Poster } from '../src/types/Poster'
 
 use(solidity)
 
-// chai
-//   .use(require('chai-as-promised'))
-//   .should();
-
 const revertMessages = {
   molochAlreadyInitialized: 'Initializable: contract is already initialized',
   molochConstructorSharesCannotBe0: 'shares cannot be 0',
@@ -131,7 +127,6 @@ const getBaalParams = async function (
     ]
   )
 
-
   const setAdminConfig = await baal.interface.encodeFunctionData('setAdminConfig', adminConfig)
   const setGovernanceConfig = await baal.interface.encodeFunctionData('setGovernanceConfig', [governanceConfig])
   const setShaman = await baal.interface.encodeFunctionData('setShamans', shamans)
@@ -143,13 +138,6 @@ const getBaalParams = async function (
 
   const initalizationActions = [setAdminConfig, setGovernanceConfig, setShaman, mintShares, mintLoot, posterFromBaal]
 
-  // const initalizationActionsMulti = encodeMultiAction(
-  //   multisend,
-  //   [setAdminConfig, setGovernanceConfig, setGuildTokens, setShaman, mintShares, mintLoot],
-  //   [baal.address, baal.address, baal.address, baal.address, baal.address, baal.address],
-  //   [BigNumber.from(0), BigNumber.from(0), BigNumber.from(0), BigNumber.from(0), BigNumber.from(0), BigNumber.from(0)],
-  //   [0, 0, 0, 0, 0, 0]
-  // )
   return {
     initParams: abiCoder.encode(
       ['string', 'string', 'address', 'address'],
@@ -311,36 +299,7 @@ describe('Tribute proposal type', function () {
     })
 
     it('EXPLOIT - Allows another proposal to spend tokens intended for tribute', async function () {
-      // expect(await weth.balanceOf(baal.address)).to.equal(0)
-
-      // await applicantWeth.approve(baal.address, 100)
-
-      // const mintShares = await baal.interface.encodeFunctionData('mintShares', [[applicant.address], [100]])
-      // const sendTribute = await applicantWeth.interface.encodeFunctionData('transferFrom', [applicant.address, baal.address, 100])
-
-      // const encodedProposal = encodeMultiAction(
-      //   multisend,
-      //   [mintShares, sendTribute],
-      //   [baal.address, weth.address],
-      //   [BigNumber.from(0), BigNumber.from(0)],
-      //   [0, 0]
-      // )
-
-      // const decoded = decodeMultiAction(multisend, encodedProposal)
-
-      // // malicious proposal sends tokens but skips issuing shares
-      // const maliciousProposal = encodeMultiAction(multisend, [sendTribute], [weth.address], [BigNumber.from(0)], [0])
-      // // const encodedProposal = encodeMultiAction(multisend, [mintShares], [baal.address], [BigNumber.from(0)], [0])
-
-      // await baal.submitProposal(encodedProposal, proposal.expiration, ethers.utils.id(proposal.details))
-      // await baal.submitProposal(maliciousProposal, proposal.expiration, ethers.utils.id(proposal.details))
-      // await baal.submitVote(1, no)
-      // await baal.submitVote(2, yes)
-      // await moveForwardPeriods(2)
-      // await baal.processProposal(1, encodedProposal)
-      // // await baal.processProposal(2, maliciousProposal)
-      // expect(await weth.balanceOf(baal.address)).to.equal(100)
-      // expect(await baal.balanceOf(applicant.address)).to.equal(0)
+      
       expect(await weth.balanceOf(gnosisSafe.address)).to.equal(0)
 
       await applicantWeth.approve(gnosisSafe.address, 100)


### PR DESCRIPTION
- Add event for tribute

- require msg.sender as applicants for tribute proposal. THis prevents a case where the dao could potentially take approved tribute for lower amount of shares requested. 