### PR TITLE
Feat/summon baal only

### DIFF
--- a/contracts/Baal.sol
+++ b/contracts/Baal.sol
@@ -1156,8 +1156,7 @@ contract BaalSummoner is ModuleProxyFactory {
         // TODO: allow safe to init baal
 
         bytes memory _anyCall = abi.encodeWithSignature("avatar()"); /*This call can be anything, it just needs to return successfully*/
-        Baal _baal = Baal(moduleProxyFactory.deployModule(template, _anyCall, _saltNonce));
- 
+        Baal _baal = Baal(moduleProxyFactory.deployModule(template, _anyCall, _saltNonce)); 
 
         bytes memory _initializationMultisendData = encodeMultisend(    
             initializationActions,

--- a/contracts/Baal.sol
+++ b/contracts/Baal.sol
@@ -1263,7 +1263,7 @@ contract BaalSummoner is ModuleProxyFactory {
             _lootSingleton,
             _sharesSingleton,
             _multisendLibrary,
-            address(_safe),
+            _safe,
             _initializationMultisendData
         );
 
@@ -1273,7 +1273,7 @@ contract BaalSummoner is ModuleProxyFactory {
             address(_baal),
             address(_baal.lootToken()),
             address(_baal.sharesToken()),
-            address(_safe)
+            _safe
         );
 
         return (address(_baal));

--- a/contracts/mock/TestAvatar.sol
+++ b/contracts/mock/TestAvatar.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.0;
+
+contract Enum {
+    enum Operation {
+        Call,
+        DelegateCall
+    }
+}
+
+contract TestAvatar {
+    address public module;
+
+    receive() external payable {}
+
+    function enableModule(address _module) external {
+        module = _module;
+    }
+
+    function disableModule(address, address) external {
+        module = address(0);
+    }
+
+    function isModuleEnabled(address _module) external view returns (bool) {
+        if (module == _module) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    function execTransactionFromModule(
+        address payable to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation
+    ) external returns (bool success) {
+        require(msg.sender == module, "Not authorized");
+        if (operation == 1) (success, ) = to.delegatecall(data);
+        else (success, ) = to.call{value: value}(data);
+    }
+
+    function execTransactionFromModuleReturnData(
+        address payable to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation
+    ) external returns (bool success, bytes memory returnData) {
+        require(msg.sender == module, "Not authorized");
+        if (operation == 1) (success, ) = to.delegatecall(data);
+        else (success, returnData) = to.call{value: value}(data);
+    }
+
+    function getModulesPaginated(address, uint256 pageSize)
+        external
+        view
+        returns (address[] memory array, address next)
+    {
+        // Init array with max page size
+        array = new address[](pageSize);
+
+        array[0] = module;
+        next = module;
+    }
+}


### PR DESCRIPTION
for situation where someone is adding a baal to a current safe. This requires enabling the module on the Safe from a precalculated baal (module) address first.