### PR TITLE
Removed details from storage in the proposal struct and just emit it.

### DIFF
--- a/contracts/Baal.sol
+++ b/contracts/Baal.sol
@@ -84,7 +84,6 @@ contract Baal is Module, EIP712Upgradeable, ReentrancyGuardUpgradeable, BaseRela
         bool[4] status; /* [cancelled, processed, passed, actionFailed] */
         address sponsor; /* address of the sponsor - set at sponsor proposal - relevant for cancellation */
         bytes32 proposalDataHash; /*hash of raw data associated with state updates*/
-        string details; /*human-readable context for proposal*/
     }
 
     /* Unborn -> Submitted -> Voting -> Grace -> Ready -> Processed
@@ -349,8 +348,7 @@ contract Baal is Module, EIP712Upgradeable, ReentrancyGuardUpgradeable, BaseRela
             0, /* highestMaxSharesAndLootAtYesVote */
             [false, false, false, false], /* [cancelled, processed, passed, actionFailed] */
             selfSponsor ? _msgSender() : address(0),
-            proposalDataHash,
-            details
+            proposalDataHash
         );
 
         if (selfSponsor) {

--- a/test/BaalSafe.test.ts
+++ b/test/BaalSafe.test.ts
@@ -2179,7 +2179,6 @@ describe("Baal contract", function () {
       expect(proposalData.yesVotes).to.equal(0);
       expect(proposalData.noVotes).to.equal(0);
       expect(proposalData.expiration).to.equal(proposal.expiration);
-      expect(proposalData.details).to.equal(ethers.utils.id(proposal.details));
       expect(hashOperation(proposal.data)).to.equal(
         proposalData.proposalDataHash
       );


### PR DESCRIPTION
A proposal and the last proposal is loaded from storage in the state() function that is used in processProposal, the details string field causes variable gas overhead on processing. We can emit this field and handle it with the indexer to save space and gas 