### PR TITLE
adding delegation signature -- currently this signature is using func…

### DIFF
--- a/contracts/SharesERC20.sol
+++ b/contracts/SharesERC20.sol
@@ -35,6 +35,7 @@ contract Shares is BaalVotes, OwnableUpgradeable, PausableUpgradeable, UUPSUpgra
         __ERC20Permit_init(name_);
         __Pausable_init();
         __Ownable_init();
+        __EIP712_init_delegation("delegation", "4");
 
     }
 

--- a/contracts/utils/DelegationEIP712Upgradeable.sol
+++ b/contracts/utils/DelegationEIP712Upgradeable.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.8.0) (utils/cryptography/EIP712.sol)
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/**
+ * @dev https://eips.ethereum.org/EIPS/eip-712[EIP 712] is a standard for hashing and signing of typed structured data.
+ *
+ * The encoding specified in the EIP is very generic, and such a generic implementation in Solidity is not feasible,
+ * thus this contract does not implement the encoding itself. Protocols need to implement the type-specific encoding
+ * they need in their contracts using a combination of `abi.encode` and `keccak256`.
+ *
+ * This contract implements the EIP 712 domain separator ({_domainSeparatorV4Delegation}) that is used as part of the encoding
+ * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA
+ * ({_hashTypedDataV4Delegation}).
+ *
+ * The implementation of the domain separator was designed to be as efficient as possible while still properly updating
+ * the chain id to protect against replay attacks on an eventual fork of the chain.
+ *
+ * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
+ * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
+ *
+ * _Available since v3.4._
+ *
+ * @custom:storage-size 52
+ */
+abstract contract DelegationEIP712Upgradeable is Initializable {
+    /* solhint-disable var-name-mixedcase */
+    bytes32 private _HASHED_NAME_DELEGATION;
+    bytes32 private _HASHED_VERSION_DELEGATION;
+    bytes32 private constant _TYPE_HASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    /* solhint-enable var-name-mixedcase */
+
+    /**
+     * @dev Initializes the domain separator and parameter caches.
+     *
+     * The meaning of `name` and `version` is specified in
+     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP 712]:
+     *
+     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.
+     * - `version`: the current major version of the signing domain.
+     *
+     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart
+     * contract upgrade].
+     */
+    function __EIP712_init_delegation(string memory name, string memory version) internal onlyInitializing {
+        __EIP712_init_unchained_delegation(name, version);
+    }
+
+    function __EIP712_init_unchained_delegation(string memory name, string memory version) internal onlyInitializing {
+        bytes32 hashedName = keccak256(bytes(name));
+        bytes32 hashedVersion = keccak256(bytes(version));
+        _HASHED_NAME_DELEGATION = hashedName;
+        _HASHED_VERSION_DELEGATION = hashedVersion;
+    }
+
+    /**
+     * @dev Returns the domain separator for the current chain.
+     */
+    function _domainSeparatorV4Delegation() internal view returns (bytes32) {
+        return _buildDomainSeparatorDelegation(_TYPE_HASH, _EIP712NameHashDelegation(), _EIP712VersionHashDelegation());
+    }
+
+    function _buildDomainSeparatorDelegation(
+        bytes32 typeHash,
+        bytes32 nameHash,
+        bytes32 versionHash
+    ) private view returns (bytes32) {
+        return keccak256(abi.encode(typeHash, nameHash, versionHash, block.chainid, address(this)));
+    }
+
+    /**
+     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this
+     * function returns the hash of the fully encoded EIP712 message for this domain.
+     *
+     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:
+     *
+     * ```solidity
+     * bytes32 digest = _hashTypedDataV4Delegation(keccak256(abi.encode(
+     *     keccak256("Mail(address to,string contents)"),
+     *     mailTo,
+     *     keccak256(bytes(mailContents))
+     * )));
+     * address signer = ECDSA.recover(digest, signature);
+     * ```
+     */
+    function _hashTypedDataV4Delegation(bytes32 structHash) internal view virtual returns (bytes32) {
+        return ECDSAUpgradeable.toTypedDataHash(_domainSeparatorV4Delegation(), structHash);
+    }
+
+    /**
+     * @dev The hash of the name parameter for the EIP712 domain.
+     *
+     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
+     * are a concern.
+     */
+    function _EIP712NameHashDelegation() internal virtual view returns (bytes32) {
+        return _HASHED_NAME_DELEGATION;
+    }
+
+    /**
+     * @dev The hash of the version parameter for the EIP712 domain.
+     *
+     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
+     * are a concern.
+     */
+    function _EIP712VersionHashDelegation() internal virtual view returns (bytes32) {
+        return _HASHED_VERSION_DELEGATION;
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[50] private __gap;
+}

--- a/src/signDelegation.ts
+++ b/src/signDelegation.ts
@@ -10,8 +10,8 @@ export default async function signDelegation(
   expiry: number
 ) {
   const domain = {
-    name,
-    version: '1',
+    name: 'delegation',
+    version: '4',
     chainId,
     verifyingContract: contractAddress,
   }


### PR DESCRIPTION
…tionality from ERC20Permit 712 signature

# Context

so I noticed that `delegationBySig` actually uses functionality from the `EIP712` that is loaded for `ERC20PermitUpgradeable` -- the nonces for permit get bumped through [`_useNonce`]() and the domain seperator for ERC20 permit gets used on [`delegationBySig`]()

this is bad, and actually i bet if we write a test to do a `delegationBySig` test, followed by another `permiterc20` tx, that test would fail becuase nonces were bumped for erc20Permit when delegationBySig was called. actually going to write this real qucik

- [X] give shares token its own eip712 delegation domain seperator
- [X] adding tests for erc20permit on shares token as well

in summary:

`delegateBySig` and `permit` action coming from our `SharesToken` -- `delegateBySig` is using the nonces from `Permit` by using the `_useNonce()` function. Along with the DomainSeperator for permit..

`permit` is coming from ERC20PermitUpgradeable while delegate by sig has no eip712 domain for itself.. 

you can see that here:

```
 function delegateBySig(
        address delegatee,
        uint256 nonce,
        uint256 expiry,
        uint8 v,
        bytes32 r,
        bytes32 s
    ) public {
        require(block.timestamp <= expiry, "ERC20Votes: signature expired");
        address signer = ECDSA.recover(
            _hashTypedDataV4( <------ this is where the domain seperator from erc20 Permit gets used for delegatebysig
                keccak256(
                    abi.encode(
                        DELEGATION_TYPEHASH,
                        keccak256(abi.encodePacked(name())),
                        delegatee,
                        nonce,
                        expiry
                    )
                )
            ),
            v,
            r,
            s
        );
        require(signer != address(0), "ERC20Votes: invalid signer (0x0)");
        require(nonce == _useNonce(signer), "ERC20Votes: invalid nonce"); <----- this accesses the nonces from permit
        _delegate(signer, delegatee);
    }
```

