### PR TITLE
fix quorum check in process proposal add test

### DIFF
--- a/contracts/Baal.sol
+++ b/contracts/Baal.sol
@@ -531,7 +531,7 @@ contract Baal is Module, EIP712Upgradeable, ReentrancyGuardUpgradeable, BaseRela
             okToExecute = false;
 
         // Make proposal fail if it didn't pass quorum
-        if (okToExecute && prop.yesVotes * 100 < quorumPercent * prop.maxTotalSharesAndLootAtVote)
+        if (okToExecute && prop.yesVotes * 100 < quorumPercent * totalShares())
             okToExecute = false;
 
         // Make proposal fail if the minRetentionPercent is exceeded

--- a/contracts/Baal.sol
+++ b/contracts/Baal.sol
@@ -77,14 +77,14 @@ contract Baal is Module, EIP712Upgradeable, ReentrancyGuardUpgradeable, BaseRela
         uint32 votingEnds; /*termination date for proposal in seconds since unix epoch - derived from `votingPeriod` set on proposal*/
         uint32 graceEnds; /*termination date for proposal in seconds since unix epoch - derived from `gracePeriod` set on proposal*/
         uint32 expiration; /*timestamp after which proposal should be considered invalid and skipped. */
-        uint32 baalGas; /* gas needed to process proposal */
-        bool[4] status; /* [cancelled, processed, passed, actionFailed] */
-        address sponsor; /* address of the sponsor - set at sponsor proposal - relevant for cancellation */
-        bytes32 proposalDataHash; /*hash of raw data associated with state updates*/
+        uint256 baalGas; /* gas needed to process proposal */
         uint256 yesVotes; /*counter for `members` `approved` 'votes' to calculate approval on processing*/
         uint256 noVotes; /*counter for `members` 'dis-approved' 'votes' to calculate approval on processing*/
         uint256 maxTotalSharesAndLootAtVote; /* highest share+loot count during any individual yes vote*/
-        uint256 maxTotalSharesAtSponsor; /* share count at sponsor*/
+        uint256 maxTotalSharesAtSponsor; /* highest share+loot count during any individual yes vote*/
+        bool[4] status; /* [cancelled, processed, passed, actionFailed] */
+        address sponsor; /* address of the sponsor - set at sponsor proposal - relevant for cancellation */
+        bytes32 proposalDataHash; /*hash of raw data associated with state updates*/
     }
 
     /* Unborn -> Submitted -> Voting -> Grace -> Ready -> Processed
@@ -314,7 +314,7 @@ contract Baal is Module, EIP712Upgradeable, ReentrancyGuardUpgradeable, BaseRela
     function submitProposal(
         bytes calldata proposalData,
         uint32 expiration,
-        uint32 baalGas,
+        uint256 baalGas,
         string calldata details
     ) external payable nonReentrant returns (uint256) {
         require(
@@ -346,13 +346,13 @@ contract Baal is Module, EIP712Upgradeable, ReentrancyGuardUpgradeable, BaseRela
                 : 0, /* graceEnds */
             expiration,
             baalGas,
-            [false, false, false, false], /* [cancelled, processed, passed, actionFailed] */
-            selfSponsor ? _msgSender() : address(0),
-            proposalDataHash,
             0, /* yes votes */
             0, /* no votes */
             selfSponsor ? totalSupply() : 0, /* maxTotalSharesAndLootAtVote */
-            selfSponsor ? totalShares() : 0 /* maxTotalSharesAtSponsor */
+            selfSponsor ? totalShares() : 0, /* maxTotalSharesAtSponsor */
+            [false, false, false, false], /* [cancelled, processed, passed, actionFailed] */
+            selfSponsor ? _msgSender() : address(0),
+            proposalDataHash
         );
 
         if (selfSponsor) {

--- a/contracts/tools/TributeMinion.sol
+++ b/contracts/tools/TributeMinion.sol
@@ -116,7 +116,7 @@ contract TributeMinion {
         uint256 shares,
         uint256 loot,
         uint32 expiration,
-        uint256 baalgas,
+        uint32 baalgas,
         string memory details
     ) external payable {
         uint32 proposalId = baal.proposalCount() + 1;

--- a/contracts/tools/TributeMinion.sol
+++ b/contracts/tools/TributeMinion.sol
@@ -116,7 +116,7 @@ contract TributeMinion {
         uint256 shares,
         uint256 loot,
         uint32 expiration,
-        uint32 baalgas,
+        uint256 baalgas,
         string memory details
     ) external payable {
         uint32 proposalId = baal.proposalCount() + 1;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -142,26 +142,26 @@ const config: HardhatUserConfig = {
       xdai: etherscan(),
       goerli: etherscan(),
       mainnet: etherscan(),
-      polygon: ""
+      polygon: "EM7G9BPWRFTG9F9GVEEJMS917NJ2WVT8ZS"
     },
     customChains: [
-      {
-        network: "gnosis",
-        chainId: 100,
-        urls: {
-          apiURL: "https://api.gnosisscan.io/api",
-          browserURL: "https://gnosisscan.io/",
-        }
-      },
-      // can only have one chainId 100 at a time
       // {
-      //   network: "xdai",
+      //   network: "gnosis",
       //   chainId: 100,
       //   urls: {
-      //     apiURL: "https://blockscout.com/xdai/mainnet/api",
-      //     browserURL: "https://blockscout.com/xdai/mainnet/",
+      //     apiURL: "https://api.gnosisscan.io/api",
+      //     browserURL: "https://gnosisscan.io/",
       //   }
-      // }
+      // },
+      // can only have one chainId 100 at a time
+      {
+        network: "xdai",
+        chainId: 100,
+        urls: {
+          apiURL: "https://blockscout.com/xdai/mainnet/api",
+          browserURL: "https://blockscout.com/xdai/mainnet/",
+        }
+      }
     ]
   },
   solidity: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -142,7 +142,7 @@ const config: HardhatUserConfig = {
       xdai: etherscan(),
       goerli: etherscan(),
       mainnet: etherscan(),
-      polygon: "EM7G9BPWRFTG9F9GVEEJMS917NJ2WVT8ZS"
+      polygon: ""
     },
     customChains: [
       // {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daohaus/baal-contracts",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Lo, also it is the time of His rain.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -46,6 +46,7 @@ async function main() {
 		networkCurrency[chainId]
 	);
 
+	const BaalFactory = await ethers.getContractFactory('Baal')
 	const baalSingleton = (await BaalFactory.deploy())
 	await baalSingleton.deployed();
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -46,28 +46,13 @@ async function main() {
 		networkCurrency[chainId]
 	);
 
-	const factory = await ethers.getContractFactory('Baal');
-	const Baal = await factory.deploy(
-        _shamans[chainId],
-        // _guildTokens[chainId],
-        [_deployer],
-        _loot,
-        _shares,
-        _minVoting,
-        _maxVoting,
-		_proposalOffering,
-        _name,
-        _symbol,
-        false,
-        false,
-	);
+	const baalSingleton = (await BaalFactory.deploy())
+	await baalSingleton.deployed();
 
-	await Baal.deployed();
-
-	const txHash = Baal.deployTransaction.hash;
+	const txHash = baalSingleton.deployTransaction.hash;
 	const receipt = await deployer.provider.getTransactionReceipt(txHash);
 	console.log('Transaction Hash:', txHash);
-	console.log('Contract Address:', Baal.address);
+	console.log('Contract Address:', baalSingleton.address);
 	console.log('Block Number:', receipt.blockNumber);
 }
 

--- a/src/addresses/deployed.js
+++ b/src/addresses/deployed.js
@@ -6,7 +6,7 @@ exports.deployments = [
     addresses: {
       lootSingleton: "0x0444AE984b9563C8480244693ED65F25B3C64a4E",
       sharesSingleton: "0x8124Cbb807A7b64123F3dEc3EF64995d8B10d3Eb",
-      baalSingleton: "0x17234C0Ae25AF09fAf57B9D5ea2B93C1f220E800",
+      baalSingleton: "0x5DcE1044A7E2E35D6524001796cee47252f18411",
       factory: "0x7e988A9db2F8597735fc68D21060Daed948a3e8C",
       valutFactory: "0x594E630efbe8dbd810c168e3878817a4094bB312",
       tributeMinion: "0x5c17BFBaB751C5ddF1Ff267acF8fF919537F39Cf",

--- a/src/addresses/deployed.js
+++ b/src/addresses/deployed.js
@@ -1,6 +1,6 @@
 exports.deployments = [
   {
-    version: "1.0.1",
+    version: "1.0.2",
     networks: ["mainnet", "gnosischain", "goerli", "polygon"],
     deployer: "0x0fe28D4424E2bB251CE3d463Cd60b7F4874Bc42b",
     addresses: {

--- a/test/BaalSafe.test.ts
+++ b/test/BaalSafe.test.ts
@@ -2945,7 +2945,7 @@ describe("Baal contract", function () {
       expect(propStatus).to.eql([false, true, true, false]); // passed [3] is true
     });
 
-    it.only("quorum should not factor loot", async function () {
+    it("quorum should not factor loot", async function () {
       const governanceConfig = abiCoder.encode(
         ["uint32", "uint32", "uint256", "uint256", "uint256", "uint256"],
         [


### PR DESCRIPTION
In the last update the quorum check was changed to check against the total supply of loot and shares high water mark instead of the total supply of shares only. this causes unwanted behavior around quorum. This reverts that change and adds a test. 